### PR TITLE
Use signal-exit package to detect exit instead of process.on('exit')

### DIFF
--- a/lockfile.js
+++ b/lockfile.js
@@ -30,7 +30,8 @@ function hasOwnProperty (obj, prop) {
   return Object.prototype.hasOwnProperty.call(obj, prop)
 }
 
-process.on('exit', function () {
+var onExit = require('signal-exit')
+onExit(function () {
   debug('exit listener')
   // cleanup
   Object.keys(locks).forEach(exports.unlockSync)

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "directories": {
     "test": "test"
   },
-  "dependencies": {},
+  "dependencies": {
+    "signal-exit": "^3.0.2"
+  },
   "devDependencies": {
     "tap": "^7.1.2",
     "touch": "0"


### PR DESCRIPTION
Fixes #21