### PR TITLE
Add Power Support ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,17 @@
 language: node_js
 sudo: false
 node_js:
+  - "14"
+  - "12"
   - "10"
   - "8"
   - "6"
   - "11"
+  
+arch:
+  - amd64
+  - ppc64le
+  
 notifications:
   email: false
 cache:


### PR DESCRIPTION
Added power support for the travis.yml file with ppc64le. This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing.

we took these projects as already being part of the ppc64le distros from debian/ubuntu. So this doesn't represent a specific user or use case, but the simple fact that this is viewed as a base/common package for Linux at this point and we enable all of these packages for Power. Our goal is to hit full parity with Intel in terms of application availability. we can't name a specific lockfile user, but usually ubuntu includes packages like this because they believe that they are the future or at least modern software and we piggy back on that decision. I know that's probably not an insightful "who are my users" answer that you are looking for but that's how we got here.